### PR TITLE
fix: update deprecated spread operator in just

### DIFF
--- a/custom-completions/just/just-completions.nu
+++ b/custom-completions/just/just-completions.nu
@@ -39,6 +39,6 @@ export def just [
     if ($recipes | is-empty) {
         ^just
     } else {
-        ^just $recipes $args
+        ^just $recipes ...$args
     }
 }


### PR DESCRIPTION
As per https://github.com/nushell/nushell/pull/11289, this should be supported in `0.89.0` and should be merged prior to `0.91.0`